### PR TITLE
Load Migrations from Package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,13 +16,10 @@
     ],
     "require": {
         "php": "^7.4|^8.0",
-        "tipoff/support": "^1.0"
+        "tipoff/support": "^1.2.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^6.0",
-        "phpunit/phpunit": "^9.3",
-        "spatie/laravel-ray": "^1.9",
-        "vimeo/psalm": "^4.4"
+        "tipoff/test-support": "^1.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/ProductsServiceProvider.php
+++ b/src/ProductsServiceProvider.php
@@ -6,7 +6,6 @@ namespace Tipoff\Products;
 
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
-use Tipoff\Products\Commands\ProductsCommand;
 
 class ProductsServiceProvider extends PackageServiceProvider
 {

--- a/src/ProductsServiceProvider.php
+++ b/src/ProductsServiceProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tipoff\Products;
 
 use Spatie\LaravelPackageTools\Package;
@@ -8,6 +10,12 @@ use Tipoff\Products\Commands\ProductsCommand;
 
 class ProductsServiceProvider extends PackageServiceProvider
 {
+    public function boot()
+    {
+        $this->loadMigrationsFrom(__DIR__ . '/../database/migrations');
+        parent::boot();
+    }
+
     public function configurePackage(Package $package): void
     {
         /*
@@ -17,9 +25,6 @@ class ProductsServiceProvider extends PackageServiceProvider
          */
         $package
             ->name('products')
-            ->hasConfigFile()
-            ->hasViews()
-            ->hasMigration('create_products_table')
-            ->hasCommand(ProductsCommand::class);
+            ->hasConfigFile();
     }
 }


### PR DESCRIPTION
- Remove .stub from /database/migrations/ files
- Update service provider to load migrations
- Declare strict types
- Require current version of tipoff/support
- Require only current version of tipoff/test-support